### PR TITLE
fix: relax systemd security settings to allow sudo execution

### DIFF
--- a/docker-updater.service
+++ b/docker-updater.service
@@ -18,11 +18,11 @@ RestartSec=30
 StandardOutput=journal
 StandardError=journal
 
-# Security settings
-NoNewPrivileges=true
+# Security settings - relaxed to allow sudo execution
+NoNewPrivileges=false
 PrivateTmp=true
-ProtectSystem=strict
-ProtectHome=true
+ProtectSystem=false
+ProtectHome=false
 ReadWritePaths=/var/lib/docker-auto-updater /var/log/docker-auto-updater /var/run/docker.sock /opt/docker-updater /app
 
 [Install]


### PR DESCRIPTION
- Set NoNewPrivileges=false to allow privilege escalation via sudo
- Disable ProtectSystem and ProtectHome restrictions
- Enables docker-updater service to execute sudo sed commands
- Resolves permission denied errors when updating compose files